### PR TITLE
GOES-16 fixes

### DIFF
--- a/goes-restitch.py
+++ b/goes-restitch.py
@@ -33,10 +33,10 @@ def dataset_name(dataset, template):
     channel_id = dataset.channel_id
 
     # Get a resolution string like 500m or 1km
-    if dataset.source_spatial_resolution >= 1.0:
-        resolution = '{}km'.format(int(np.round(dataset.source_spatial_resolution)))
+    if dataset.request_spatial_resolution >= 1.0:
+        resolution = '{:.0f}km'.format(dataset.request_spatial_resolution)
     else:
-        resolution = '{}m'.format(int(np.round(dataset.source_spatial_resolution * 1000.)))
+        resolution = '{}m'.format(int(dataset.request_spatial_resolution * 10) * 100)
 
     # Get lon/lat out to 1 decimal point
     center_lat = '{0:.1f}{1}'.format(np.fabs(dataset.product_center_latitude),
@@ -126,7 +126,7 @@ def find_files(source_dir):
 
 async def read_disk(source_dir, sinks):
     r"""Read files from disk and asynchronously put them in queue.
-    
+
     Integrates find_files into our asynchronous framework.
     """
     for product in find_files(source_dir):
@@ -148,7 +148,7 @@ async def read_disk(source_dir, sinks):
 #
 class AssemblerManager(defaultdict):
     r"""Manages Assembler instances.
-    
+
     Dispatches tiles that have arrived and dispatches them to the appropriate
     file assembler, creating them as necessary.
     """
@@ -281,7 +281,7 @@ class Assembler:
 
 def read_netcdf_from_memory(mem):
     r"""Return a netCDF4.Dataset from data in memory.
-    
+
     Uses a temp file until we have support in netCDF4-python.
     """
     try:

--- a/goes-restitch.py
+++ b/goes-restitch.py
@@ -302,7 +302,7 @@ def setup_arg_parser():
     parser = argparse.ArgumentParser(description='Assemble netCDF4 tiles of GOES data into '
                                                  'single files.')
     parser.add_argument('-d', '--data_dir', help='Base output directory', type=str,
-                        default='/data/ldm/pub/native/radar/level2')
+                        default='/data/ldm/pub/native/satellite/GOES')
     parser.add_argument('-t', '--timeout', help='Timeout in seconds for waiting for data',
                         default=15, type=int)
     parser.add_argument('-s', '--source', help='Source directory for data tiles', type=str,

--- a/goes-restitch.py
+++ b/goes-restitch.py
@@ -315,7 +315,7 @@ def setup_arg_parser():
                         'string format specification',
                         default=os.path.join('{satellite}', '{scene}',
                                              'Channel{channel_id:02d}', '{dt:%Y%m%d}',
-                                             '{satellite}_{dt:%Y%m%d}_{dt:%H%M%S}_'
+                                             '{satellite}_{scene}_{dt:%Y%m%d}_{dt:%H%M%S}_'
                                              '{channel:.2f}_{resolution}_{lat}_{lon}.nc4'))
     parser.add_argument('-l', '--log', help='Filename to log information to. Uses standard'
                         ' out if not given.', type=str, default='')

--- a/goes-restitch.py
+++ b/goes-restitch.py
@@ -25,6 +25,10 @@ def copy_attrs(src, dest, skip):
         if not skip(attr):
             setattr(dest, attr, getattr(src, attr))
 
+            # Make the spheroid axis lengths CF-compliant
+            if attr in {'semi_major', 'semi_minor'} and hasattr(src, 'grid_mapping_name'):
+                setattr(dest, attr + '_axis', getattr(src, attr))
+
 
 def dataset_name(dataset, template):
     r"""Create an appropriate file path from a GOES dataset."""

--- a/goes-restitch.py
+++ b/goes-restitch.py
@@ -54,6 +54,12 @@ def dataset_name(dataset, template):
                                      'E' if dataset.product_center_longitude > 0 else 'W')
     scene = dataset.source_scene
 
+    # Need special handling for full disk images to better name NWS regional images
+    if scene == 'FullDisk':
+        region = dataset.product_name.split('-')[0]
+        if region != 'TFD':
+            scene = region
+
     # Parse start time into something we can use
     dt = goes_time_to_dt(dataset.start_date_time)
     return template.format(satellite=sat_id, channel=channel, resolution=resolution, dt=dt,


### PR DESCRIPTION
Fixing up a few issues, both self-inflicted and external:
- Make resolution in filename correct--6km full disk images were incorrectly labelled
- Add scene name to default filename
- Fix mention of radar in default output file path (copy/paste oops)
- Fix CF-compliance of files
  - Make grid mapping attributes correct (`semi_major`->`semi_major_axis`, same for minor)
  - Add scalar coordinate variable for time, which eliminates propagation of code to parse yet another dumb string format

Still need to address the problem with Puerto Rico sectors (and Alaska/Hawaii for GOES-17), where they are mixed with Full Disk images.